### PR TITLE
Increase audio manipulation SR to 32kHz

### DIFF
--- a/psifx/audio/manipulation/tool.py
+++ b/psifx/audio/manipulation/tool.py
@@ -56,7 +56,7 @@ class ManipulationTool(Tool):
         audio_path.parent.mkdir(parents=True, exist_ok=True)
         (
             ffmpeg.input(str(video_path))
-            .audio.output(str(audio_path), **{"q:a": 0, "ac": 1, "ar": 16000})
+            .audio.output(str(audio_path), **{"q:a": 0, "ac": 1, "ar": 32000})
             .overwrite_output()
             .run(quiet=self.verbose <= 1)
         )


### PR DESCRIPTION
Pyannote resamples to 16k regardless of the input sampling rate (see https://huggingface.co/pyannote/speaker-diarization-3.0#:~:text=It%20ingests%20mono%20audio%20sampled,to%2016kHz%20automatically%20upon%20loading.) 