### PR TITLE
pyannote identification default sample rate to 32kHz rather than 16kHz

### DIFF
--- a/psifx/audio/identification/pyannote/tool.py
+++ b/psifx/audio/identification/pyannote/tool.py
@@ -24,7 +24,7 @@ def cropped_waveform(
     path: Union[str, Path],
     start: float,
     end: float,
-    sample_rate: int = 16000,
+    sample_rate: int = 32000,
 ) -> Tensor:
     """
     Crops an audio track and returns its corresponding waveform.


### PR DESCRIPTION
tested across diarization, identification, and other manipulation tools