### PR TITLE
Hotfix: HF/torch compatibility for stable pip+docker runtime

### DIFF
--- a/psifx/audio/diarization/pyannote/tool.py
+++ b/psifx/audio/diarization/pyannote/tool.py
@@ -1,6 +1,8 @@
 """pyannote speaker diarization tool."""
+from collections import OrderedDict, defaultdict
 import os
 from typing import Optional, Union
+from typing import Any
 
 from pathlib import Path
 from tqdm import tqdm
@@ -11,6 +13,7 @@ from pyannote.core import Annotation
 
 from psifx.audio.diarization.tool import DiarizationTool
 from psifx.io import rttm, wav
+from psifx.utils.huggingface import patch_hf_hub_download_use_auth_token
 
 
 class PyannoteDiarizationTool(DiarizationTool):
@@ -40,11 +43,13 @@ class PyannoteDiarizationTool(DiarizationTool):
 
         self.model_name = model_name
         self.api_token = api_token or os.environ.get('HF_TOKEN')
+        os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
         self._register_torch_safe_globals()
+        patch_hf_hub_download_use_auth_token()
 
         self.model: Pipeline = Pipeline.from_pretrained(
             checkpoint_path=model_name,
-            use_auth_token=api_token,
+            use_auth_token=self.api_token,
         ).to(device=torch.device(device))
 
     def inference(
@@ -136,6 +141,28 @@ class PyannoteDiarizationTool(DiarizationTool):
             safe_globals.append(ContainerMetadata)
         except Exception:
             pass
+
+        try:
+            import omegaconf.base as omegaconf_base
+
+            safe_globals.extend(
+                value for value in vars(omegaconf_base).values() if isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        try:
+            import omegaconf.nodes as omegaconf_nodes
+
+            safe_globals.extend(
+                value
+                for name, value in vars(omegaconf_nodes).items()
+                if name.endswith("Node") and isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        safe_globals.extend([Any, list, dict, tuple, set, int, float, bool, str, bytes, OrderedDict, defaultdict])
 
         if safe_globals:
             add_safe_globals(safe_globals)

--- a/psifx/audio/identification/pyannote/tool.py
+++ b/psifx/audio/identification/pyannote/tool.py
@@ -1,6 +1,8 @@
 """pyannote speaker identification tool."""
+from collections import OrderedDict, defaultdict
 import os
 from typing import Union, Optional, Sequence
+from typing import Any
 
 from itertools import permutations
 from pathlib import Path
@@ -18,6 +20,7 @@ from pyannote.core import Segment
 
 from psifx.audio.identification.tool import IdentificationTool
 from psifx.io import rttm, json, wav
+from psifx.utils.huggingface import patch_hf_hub_download_use_auth_token
 
 def cropped_waveform(
     path: Union[str, Path],
@@ -71,12 +74,14 @@ class PyannoteIdentificationTool(IdentificationTool):
         )
 
         self.api_token = api_token or os.environ.get('HF_TOKEN')
+        os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
         self._register_torch_safe_globals()
+        patch_hf_hub_download_use_auth_token()
         self.models = {
             name: PretrainedSpeakerEmbedding(
                 embedding=name,
                 device=torch.device(device),
-                use_auth_token=api_token,
+                use_auth_token=self.api_token,
             )
             for name in model_names
         }
@@ -233,6 +238,28 @@ class PyannoteIdentificationTool(IdentificationTool):
             safe_globals.append(ContainerMetadata)
         except Exception:
             pass
+
+        try:
+            import omegaconf.base as omegaconf_base
+
+            safe_globals.extend(
+                value for value in vars(omegaconf_base).values() if isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        try:
+            import omegaconf.nodes as omegaconf_nodes
+
+            safe_globals.extend(
+                value
+                for name, value in vars(omegaconf_nodes).items()
+                if name.endswith("Node") and isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        safe_globals.extend([Any, list, dict, tuple, set, int, float, bool, str, bytes, OrderedDict, defaultdict])
 
         if safe_globals:
             add_safe_globals(safe_globals)

--- a/psifx/audio/transcription/whisper/tool.py
+++ b/psifx/audio/transcription/whisper/tool.py
@@ -1,9 +1,13 @@
 """WhisperX transcription tool."""
+from collections import OrderedDict, defaultdict
+import os
 from typing import Union, Optional
+from typing import Any
 from pathlib import Path
 import torch
 from psifx.audio.transcription.tool import TranscriptionTool
 from psifx.io import vtt, wav
+from psifx.utils.huggingface import patch_hf_hub_download_use_auth_token
 import whisperx
 
 
@@ -36,8 +40,10 @@ class WhisperXTool(TranscriptionTool):
             raise NameError(f"task should be 'transcribe' or 'translate', got '{task}' instead")
         self.task = task
         compute_type = "float16" if device == 'cuda' else "float32"
+        os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
 
         self._register_torch_safe_globals()
+        patch_hf_hub_download_use_auth_token()
         self.pipeline = whisperx.load_model(model_name, task=task, device=device, compute_type=compute_type)
 
     def inference(
@@ -109,6 +115,28 @@ class WhisperXTool(TranscriptionTool):
             safe_globals.append(ContainerMetadata)
         except Exception:
             pass
+
+        try:
+            import omegaconf.base as omegaconf_base
+
+            safe_globals.extend(
+                value for value in vars(omegaconf_base).values() if isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        try:
+            import omegaconf.nodes as omegaconf_nodes
+
+            safe_globals.extend(
+                value
+                for name, value in vars(omegaconf_nodes).items()
+                if name.endswith("Node") and isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        safe_globals.extend([Any, list, dict, tuple, set, int, float, bool, str, bytes, OrderedDict, defaultdict])
 
         if safe_globals:
             add_safe_globals(safe_globals)

--- a/psifx/utils/huggingface.py
+++ b/psifx/utils/huggingface.py
@@ -1,0 +1,52 @@
+"""Compatibility helpers for Hugging Face integrations."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from functools import wraps
+
+
+def patch_hf_hub_download_use_auth_token() -> None:
+    """
+    Patch ``hf_hub_download`` so callers using ``use_auth_token=...`` still work.
+
+    Some dependencies still call ``hf_hub_download(..., use_auth_token=...)`` while
+    newer ``huggingface_hub`` versions expect ``token=...``.
+    """
+    try:
+        import huggingface_hub
+    except Exception:
+        return
+
+    hf_hub_download = getattr(huggingface_hub, "hf_hub_download", None)
+    if hf_hub_download is None:
+        return
+
+    try:
+        signature = inspect.signature(hf_hub_download)
+    except (TypeError, ValueError):
+        signature = None
+
+    if signature is not None and "use_auth_token" in signature.parameters:
+        return
+
+    @wraps(hf_hub_download)
+    def compat_hf_hub_download(*args, use_auth_token=None, **kwargs):
+        if use_auth_token is not None and "token" not in kwargs:
+            kwargs["token"] = use_auth_token
+        return hf_hub_download(*args, **kwargs)
+
+    huggingface_hub.hf_hub_download = compat_hf_hub_download
+
+    # pyannote imports hf_hub_download directly in these modules.
+    for module_name in (
+        "pyannote.audio.core.pipeline",
+        "pyannote.audio.core.model",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+        if hasattr(module, "hf_hub_download"):
+            setattr(module, "hf_hub_download", compat_hf_hub_download)

--- a/psifx/video/tracking/sam3/tool.py
+++ b/psifx/video/tracking/sam3/tool.py
@@ -1,8 +1,10 @@
 """sam3 tracking tool."""
 
 from collections import deque
+from collections import OrderedDict, defaultdict
+import os
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
 import cv2
 import numpy as np
@@ -31,6 +33,8 @@ class Sam3TrackingTool(TrackingTool):
         )
         self.compute_dtype = torch.bfloat16 if self.device == "cuda" else torch.float32
         self.model_path = model_path
+        self.api_token = api_token or os.environ.get("HF_TOKEN")
+        os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
         # Keep raw video frames on CPU to cap GPU memory usage for long clips.
         self.video_storage_device = "cpu" if self.device == "cuda" else self.device
 
@@ -39,10 +43,10 @@ class Sam3TrackingTool(TrackingTool):
 
         try:
             self._register_torch_safe_globals()
-            self.model = Sam3VideoModel.from_pretrained(self.model_path, token=api_token).to(
+            self.model = Sam3VideoModel.from_pretrained(self.model_path, token=self.api_token).to(
                 self.device, dtype=self.compute_dtype
             )
-            self.processor = Sam3VideoProcessor.from_pretrained(self.model_path, token=api_token)
+            self.processor = Sam3VideoProcessor.from_pretrained(self.model_path, token=self.api_token)
         except Exception as exc:
             raise RuntimeError(
                 "Failed to load SAM3 model. "
@@ -369,6 +373,28 @@ class Sam3TrackingTool(TrackingTool):
             safe_globals.append(ContainerMetadata)
         except Exception:
             pass
+
+        try:
+            import omegaconf.base as omegaconf_base
+
+            safe_globals.extend(
+                value for value in vars(omegaconf_base).values() if isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        try:
+            import omegaconf.nodes as omegaconf_nodes
+
+            safe_globals.extend(
+                value
+                for name, value in vars(omegaconf_nodes).items()
+                if name.endswith("Node") and isinstance(value, type)
+            )
+        except Exception:
+            pass
+
+        safe_globals.extend([Any, list, dict, tuple, set, int, float, bool, str, bytes, OrderedDict, defaultdict])
 
         if safe_globals:
             add_safe_globals(safe_globals)


### PR DESCRIPTION
## Summary
This hotfix hardens runtime compatibility after the SAM3 merge so pip and Docker installs remain stable with current dependency versions.

### Changes
- Add Hugging Face download compatibility shim for legacy `use_auth_token` callers with newer `huggingface_hub`.
- Ensure token fallback consistently uses `HF_TOKEN` across pyannote/SAM3 tool initialization paths.
- Stabilize torch checkpoint loading for WhisperX/pyannote/SAM3 by setting `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1` in tool initialization (trusted checkpoint path).
- Expand safe-global registration for torch deserialization (OmegaConf + common builtins/containers).

### Files
- `psifx/utils/huggingface.py`
- `psifx/audio/diarization/pyannote/tool.py`
- `psifx/audio/identification/pyannote/tool.py`
- `psifx/audio/transcription/whisper/tool.py`
- `psifx/video/tracking/sam3/tool.py`

## Local Validation (deployed image)
Validated using `psifx/psifx:0.2.1` with workspace-mounted hotfix code:
- `pytest -rs tests/integration/audio/test_transcription.py` -> **passed**
- `pytest -rs tests/integration/audio/test_diarization.py tests/integration/audio/test_identification.py` -> failures are now gated-model access/token-permission related (no longer hf_hub signature mismatch or torch weights_only crashes).

## Notes
- This PR intentionally excludes workflow-file edits (workflow update handled separately on `main`).
