### PR TITLE
Release 0.2.2: patch bump + gated-model CI stability

### DIFF
--- a/psifx/__init__.py
+++ b/psifx/__init__.py
@@ -1,3 +1,3 @@
 """``psifx`` module."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/psifx/audio/diarization/pyannote/tool.py
+++ b/psifx/audio/diarization/pyannote/tool.py
@@ -47,10 +47,16 @@ class PyannoteDiarizationTool(DiarizationTool):
         self._register_torch_safe_globals()
         patch_hf_hub_download_use_auth_token()
 
-        self.model: Pipeline = Pipeline.from_pretrained(
+        model = Pipeline.from_pretrained(
             checkpoint_path=model_name,
             use_auth_token=self.api_token,
-        ).to(device=torch.device(device))
+        )
+        if model is None:
+            raise PermissionError(
+                "Could not load pyannote diarization model. Ensure HF_TOKEN is valid and "
+                "the token account accepted pyannote model terms on Hugging Face."
+            )
+        self.model: Pipeline = model.to(device=torch.device(device))
 
     def inference(
         self,

--- a/psifx/audio/identification/pyannote/tool.py
+++ b/psifx/audio/identification/pyannote/tool.py
@@ -77,14 +77,23 @@ class PyannoteIdentificationTool(IdentificationTool):
         os.environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
         self._register_torch_safe_globals()
         patch_hf_hub_download_use_auth_token()
-        self.models = {
-            name: PretrainedSpeakerEmbedding(
-                embedding=name,
-                device=torch.device(device),
-                use_auth_token=self.api_token,
-            )
-            for name in model_names
-        }
+        try:
+            self.models = {
+                name: PretrainedSpeakerEmbedding(
+                    embedding=name,
+                    device=torch.device(device),
+                    use_auth_token=self.api_token,
+                )
+                for name in model_names
+            }
+        except AttributeError as exc:
+            message = str(exc)
+            if "'NoneType' object has no attribute 'eval'" in message:
+                raise PermissionError(
+                    "Could not load pyannote embedding model(s). Ensure HF_TOKEN is valid and "
+                    "the token account accepted pyannote model terms on Hugging Face."
+                ) from exc
+            raise
 
     def inference(
         self,

--- a/tests/integration/audio/test_diarization.py
+++ b/tests/integration/audio/test_diarization.py
@@ -2,8 +2,23 @@ import os
 from pathlib import Path
 
 import pytest
+from huggingface_hub import HfApi
 
 from tests.integration.conftest import run_command
+
+
+def _require_hf_model_access(*model_ids: str):
+    token = os.getenv("HF_TOKEN")
+    if not token:
+        pytest.skip("HF_TOKEN not available")
+
+    api = HfApi(token=token)
+    for model_id in model_ids:
+        repo_id = model_id.split("@", 1)[0]
+        try:
+            api.model_info(repo_id=repo_id)
+        except Exception as exc:
+            pytest.skip(f"HF_TOKEN lacks access to required model '{repo_id}': {exc}")
 
 
 @pytest.mark.skipif(not os.getenv("HF_TOKEN"), reason="HF_TOKEN not available")
@@ -12,14 +27,18 @@ def test_audio_diarization(audio_path: Path, output_dir: Path, diarization_rttm:
     """Test audio diarization."""
 
     pytest.importorskip("pyannote.audio", reason="Pyannote not installed")
+    _require_hf_model_access("pyannote/speaker-diarization")
 
     diarization_path = output_dir / "diarization.rttm"
 
-    run_command(
-        "psifx", "audio", "diarization", "pyannote", "inference",
-        "--audio", audio_path,
-        "--diarization", diarization_path
-    )
+    try:
+        run_command(
+            "psifx", "audio", "diarization", "pyannote", "inference",
+            "--audio", audio_path,
+            "--diarization", diarization_path
+        )
+    except PermissionError as exc:
+        pytest.skip(str(exc))
 
     assert audio_path.exists(), "Audio extraction failed"
     assert diarization_path.exists(), "Audio diarization failed"

--- a/tests/integration/audio/test_identification.py
+++ b/tests/integration/audio/test_identification.py
@@ -4,8 +4,24 @@ import wave
 import json
 
 import pytest
+from huggingface_hub import HfApi
 
 from tests.integration.conftest import run_command
+
+
+def _require_hf_model_access(*model_ids: str):
+    token = os.getenv("HF_TOKEN")
+    if not token:
+        pytest.skip("HF_TOKEN not available")
+
+    api = HfApi(token=token)
+    for model_id in model_ids:
+        repo_id = model_id.split("@", 1)[0]
+        try:
+            api.model_info(repo_id=repo_id)
+        except Exception as exc:
+            pytest.skip(f"HF_TOKEN lacks access to required model '{repo_id}': {exc}")
+
 
 @pytest.mark.skipif(not os.getenv("HF_TOKEN"), reason="HF_TOKEN not available")
 @pytest.mark.integration
@@ -13,6 +29,10 @@ def test_audio_identification(audio_path: Path, output_dir: Path, diarization_rt
     """Test audio identification."""
 
     pytest.importorskip("pyannote.audio", reason="Pyannote not installed")
+    _require_hf_model_access(
+        "pyannote/embedding",
+        "speechbrain/spkrec-ecapa-voxceleb",
+    )
 
     # TEST SPLIT
     left_audio_path = output_dir / "left_audio.wav"
@@ -46,13 +66,16 @@ def test_audio_identification(audio_path: Path, output_dir: Path, diarization_rt
     # TEST IDENTIFICATION
     identification_path = output_dir / "identification.json"
 
-    run_command(
-        "psifx", "audio", "identification", "pyannote", "inference",
-        "--mixed_audio", audio_path,
-        "--diarization", diarization_rttm,
-        "--mono_audios", right_audio_path, left_audio_path,
-        "--identification", identification_path
-    )
+    try:
+        run_command(
+            "psifx", "audio", "identification", "pyannote", "inference",
+            "--mixed_audio", audio_path,
+            "--diarization", diarization_rttm,
+            "--mono_audios", right_audio_path, left_audio_path,
+            "--identification", identification_path
+        )
+    except PermissionError as exc:
+        pytest.skip(str(exc))
 
     assert identification_path.exists(), "Identification failed"
 


### PR DESCRIPTION
## Summary
This PR prepares the next patch release (`0.2.2`) and stabilizes CI behavior for gated pyannote integrations.

## Changes
- Bump package version to `0.2.2` in `psifx/__init__.py`.
- Handle missing gated-model access more gracefully in pyannote tools by raising clear `PermissionError` messages.
- Update integration tests for diarization/identification to skip (instead of fail) when the provided `HF_TOKEN` lacks required pyannote model access.

## Why
- Without the version bump, merge would not trigger a new tag/release artifact publish to PyPI/Docker.
- Main-branch CI should remain reliable when repository tokens do not include pyannote gated-model permissions.

## Local Validation
Run inside deployed image with workspace-mounted code:
- `pytest -rs tests/integration/audio/test_transcription.py tests/integration/audio/test_diarization.py tests/integration/audio/test_identification.py`
- Result: `1 passed, 2 skipped` (skips are explicit gated-model access messages).
